### PR TITLE
Adding definition for FAST internal EXP bus. Needed when using Raspbe…

### DIFF
--- a/mpf/config_spec.yaml
+++ b/mpf/config_spec.yaml
@@ -628,6 +628,7 @@ fast:
     __type__: config
     net: single|subconfig(fast_net)|None
     exp: single|subconfig(fast_exp)|None
+    exp_int: single|subconfig(fast_exp)|None    
     aud: single|subconfig(fast_aud)|None
     seg: single|subconfig(fast_seg)|None
     dmd: single|subconfig(fast_dmd)|None
@@ -655,6 +656,13 @@ fast_io_loop:
     model: single|str|  # FP-I/O-0804, etc.
     order: single|enum(1,2,3,4,5,6,7,8,9)|
 fast_exp:
+    port: list|str|auto
+    baud: single|int|921600
+    debug: single|bool|false
+    console_log: single|enum(none,basic,full)|none
+    file_log: single|enum(none,basic,full)|basic
+    boards: dict|str:subconfig(fast_exp_board)|
+fast_exp_int:
     port: list|str|auto
     baud: single|int|921600
     debug: single|bool|false

--- a/mpf/platforms/fast/fast.py
+++ b/mpf/platforms/fast/fast.py
@@ -45,7 +45,7 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                  "io_boards", "io_boards_by_name", "switches_initialized",
                  "drivers_initialized", "audio_interface"]
 
-    port_types = ['net', 'exp', 'aud', 'dmd', 'rgb', 'seg', 'emu']
+    port_types = ['net', 'exp', 'exp_int', 'aud', 'dmd', 'rgb', 'seg', 'emu']
 
     def __init__(self, machine):
         """Initialize FAST hardware platform.
@@ -247,6 +247,11 @@ class FastHardwarePlatform(ServoPlatform, LightsPlatform, RgbDmdPlatform,
                     FastExpCommunicator
                 communicator = FastExpCommunicator(platform=self, processor=port, config=config)
                 self.serial_connections['exp'] = communicator
+            elif port == 'exp_int':
+                from mpf.platforms.fast.communicators.exp import \
+                    FastExpCommunicator
+                communicator = FastExpCommunicator(platform=self, processor=port, config=config)
+                self.serial_connections['exp_int'] = communicator                
             elif port == 'seg':
                 from mpf.platforms.fast.communicators.seg import \
                     FastSegCommunicator


### PR DESCRIPTION
…rry Pi directly connected to Neuron board, when Neuron LED expansion is needed in addition to primary EXP bus. Allows MPF config to explicitly set serial port for internal and external EXP bus. These interfaces are merged together when connecting via USB, but are broken out to separate pins on the Neuron Raspberry Pi header.